### PR TITLE
Set react-native as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   },
   "homepage": "https://github.com/KelseyRegan/react-native-qrcode-view#readme",
   "dependencies": {
-    "react-native": "^0.12.0",
     "javascript-qrcode": "^1.0.7"
+  },
+  "peerDependencies": {
+    "react-native": "^0.21.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "javascript-qrcode": "^1.0.7"
   },
   "peerDependencies": {
-    "react-native": "^0.21.0"
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
Set `react-native` as a [peer dependency](https://nodejs.org/en/blog/npm/peer-dependencies/) so that `npm install` does not force the use & download of a specific version of `react-native`, would fix https://github.com/KelseyRegan/react-native-qrcode-view/issues/1.
